### PR TITLE
Unavailable sensor fix

### DIFF
--- a/custom_components/octopus_intelligent/manifest.json
+++ b/custom_components/octopus_intelligent/manifest.json
@@ -1,7 +1,7 @@
 {    
   "domain": "octopus_intelligent",
   "name": "Octopus Intelligent Tariff",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "documentation": "https://github.com/megakid/ha_octopus_intelligent",
   "issue_tracker": "https://github.com/megakid/ha_octopus_intelligent/issues",
   "codeowners": ["@megakid"],

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -23,7 +23,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
             # Name of the data. For logging purposes.
             name="Octopus Intelligent",
             # Polling interval. Will only be polled if there are subscribers.
-            update_interval=timedelta(seconds=300),
+            update_interval=timedelta(seconds=120),
         )
         self._hass = hass
         self._api_key = api_key
@@ -48,7 +48,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(30):
+            async with async_timeout.timeout(60):
                 return await self.client.async_get_combined_state(self._account_id)
         # except ApiAuthError as err:
         #     # Raising ConfigEntryAuthFailed will cancel future updates


### PR DESCRIPTION
I found the issue causing the sensors to become unavailable was due to some very choppy performance with the Octopus APIs moving form a call time of 1-3 seconds to 30 seconds or greater at times. This longer call duration then exceeded to timeout that was defined for the HA poll of 30 secs and therefore left the sensors unavailable. Fix is simple increase HA async task timeout to 60 seconds. Also changed the polling to every 2 mins and all is good. 