### PR TITLE
Fix issues #35 #36: Planned dispatch source is None

### DIFF
--- a/custom_components/octopus_intelligent/__init__.py
+++ b/custom_components/octopus_intelligent/__init__.py
@@ -65,3 +65,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Octopus Intelligent System component setup finished")
     return True
 
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Called when the config entry is removed (the integration is deleted)."""
+    octopus_system: OctopusIntelligentSystem = (
+        hass.data[DOMAIN][entry.entry_id][OCTOPUS_SYSTEM]
+    )
+    try:
+        await octopus_system.async_remove_entry()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        _LOGGER.error(ex)

--- a/custom_components/octopus_intelligent/persistent_data.py
+++ b/custom_components/octopus_intelligent/persistent_data.py
@@ -1,0 +1,109 @@
+"""Persistent data storage for the integration, based on the HASS helpers.storage.Store class."""
+import logging
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+from homeassistant.exceptions import IntegrationError
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PersistentData:
+    """JSON-serialisable persistent data."""
+
+    last_seen_planned_dispatch_source: str = "smart-charge"
+
+    def set_values(self, data: dict[str, Any]):
+        """Assign values from the given dict to this dataclass."""
+        # Explicitly assign each field separately instead of using some '**data'
+        # unpacking syntax in order to be future-proof against schema changes.
+        self.last_seen_planned_dispatch_source = data.get(
+            "last_seen_planned_dispatch_source",
+            self.last_seen_planned_dispatch_source,
+        )
+
+
+class PersistentDataStore:
+    """Wrapper around hass.helpers.storage.Store, with a lazy saving feature.
+
+    Home Assistant may be hosted on an edge device like the Raspberry Pi, with data
+    stored on an SD Card that physically "wears" when data is written. To mitigate this
+    issue, the lazy save feature delays writting data to "disk" until the HASS STOP event
+    is fired, indicating that Home Assistant is about to quit or restart. This includes
+    the frontend web UI 'Restart' command, the "docker container stop" command, CTRL-C on
+    the command line, and generally when the HASS process receives the SIGTERM signal.
+    """
+
+    def __init__(
+        self,
+        data: PersistentData,
+        hass: HomeAssistant,
+        account_id: str,
+        lazy_save=True,
+    ):
+        self.data = data
+        self._hass = hass
+        self._store = Store[dict[str, Any]](
+            hass=hass,
+            key=f"{DOMAIN}.{account_id}",
+            version=1,
+            minor_version=1,
+        )
+        self._stop_event_listener: CALLBACK_TYPE | None = None
+        self.lazy_save = lazy_save
+
+    @property
+    def lazy_save(self) -> bool:
+        """Return whether lazy data saving is enabled."""
+        return bool(self._stop_event_listener)
+
+    @lazy_save.setter
+    def lazy_save(self, enable: bool):
+        """Enable/disable automatically calling self.save() on the HASS STOP event."""
+
+        async def _on_hass_stop(_: Event):
+            await self.save(raise_on_error=False)
+
+        if enable:
+            self._stop_event_listener = self._hass.bus.async_listen(
+                EVENT_HOMEASSISTANT_STOP, _on_hass_stop
+            )
+        elif self._stop_event_listener:
+            self._stop_event_listener()
+            self._stop_event_listener = None
+
+    async def load(self):
+        """Load the data from persistent storage."""
+        data = None
+        try:
+            data = await self._store.async_load()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            _LOGGER.error(ex)
+        if isinstance(data, dict):
+            self.data.set_values(data)
+
+    async def save(self, raise_on_error=False):
+        """Save the data to persistent storage."""
+        try:
+            await self._store.async_save(asdict(self.data))
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            msg = f"Error saving persistent data: {ex}"
+            if raise_on_error:
+                raise IntegrationError(msg) from ex
+            _LOGGER.error(msg)
+
+    async def remove(self, disable_lazy_save=True):
+        """Remove the data from persistent storage (delete the JSON file on disk)."""
+        if disable_lazy_save:
+            self.lazy_save = False
+        try:
+            await self._store.async_remove()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            _LOGGER.error("Error removing persistent data: %s", ex)


### PR DESCRIPTION
This PR proposes a fix for issues #35 and #36. As @matt7aylor had [pointed out](https://github.com/megakid/ha_octopus_intelligent/issues/35#issuecomment-1949942197), sometimes the `source` attribute in the Octopus API planned dispatch list gets changed from `"source": "smart-charge"` to `"source": None`. The proposed solution / workaround is to remember the last seen non-None source and use it when `source` is None. For example:

Initially, `'source': 'smart-charge'`:
```
2024-02-28 05:55:02.838 ...
 'plannedDispatches': [{'chargeKwh': '-7.31',
                        'endDtUtc': '2024-02-28 08:30:00+00:00',
                        'meta': {'location': None, 'source': 'smart-charge'},
                        'startDtUtc': '2024-02-28 05:20:00+00:00'}],
```
Then it goes rogue, `'source': None`:
```
2024-02-28 06:00:04.618 ...
 'plannedDispatches': [{'chargeKwh': '-5.77',
                        'endDtUtc': '2024-02-28 08:30:00+00:00',
                        'meta': {'location': None, 'source': None},
                        'startDtUtc': '2024-02-28 06:00:00+00:00'}],
```
The proposed solution replaces `'source': None` with `'source': 'smart-charge'` (in this particular example) before passing it on to the integration sensors etc.

The proposed solution also introduces a `PersistentData` class that uses the Home Assistant `helpers.storage.Store` class to persist the last seen non-None `source` to disk when Home Assistant is stopped / restarted, and restores it when the integration is loaded again.

It is worth noting that initially I tried something else. I looked at the Octopus GraphQL schema for [plannedDispatches](https://docs.octopus.energy/graphql/reference/queries#queries-planneddispatches) and noticed that they document two `source` attributes, one in the `meta` inner object and one in the outer scope:

_Octopus API query documentation:_
```graphql
query PlannedDispatches($accountNumber: String!) {
  plannedDispatches(accountNumber: $accountNumber) {
    startDt
    endDt
    deltaKwh
    delta
    source
    meta {
        source
        location
    }
  }
}
```
_Octopus API response documentation:_
```json
{
  "data": {
    "plannedDispatches": [
      {
        "startDt": "abc123",
        "endDt": "abc123",
        "deltaKwh": 1,
        "delta": 1.0,
        "source": "abc123",
        "meta": {
            "source": "abc123",
            "location": "abc123"
        }
      }
    ]
  }
}
```
So I tried modifying the query in `graphql_client.py` [__async_get_combined_state()](https://github.com/megakid/ha_octopus_intelligent/blob/v1.6.3/custom_components/octopus_intelligent/graphql_client.py#L259) to include both `source` attributes, in the hope that when one is None, the other isn’t. Alas, I observed that the newly added outer `source` attribute was always `None`, regardless of the whether the `meta.source` attribute was `None` or not. Example:

```py
2024-03-03 22:23:19.619 ...
 'plannedDispatches': [{'chargeKwh': '-12.00',
                        'endDtUtc': '2024-03-04 04:00:00+00:00',
                        'meta': {'location': None, 'source': 'smart-charge'},
                        'source': None,
                        'startDtUtc': '2024-03-03 22:00:00+00:00'}],
...
2024-03-03 22:28:20.464 ...
 'plannedDispatches': [{'chargeKwh': '-12.00',
                        'endDtUtc': '2024-03-04 04:00:00+00:00',
                        'meta': {'location': None, 'source': None},
                        'source': None,
                        'startDtUtc': '2024-03-03 22:00:00+00:00'}],
```
