### PR TITLE
Fix RuntimeWarning: coroutine 'OctopusIntelligentSystem.start' was never awaited

### DIFF
--- a/custom_components/octopus_intelligent/__init__.py
+++ b/custom_components/octopus_intelligent/__init__.py
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     try:
-        await hass.async_add_executor_job(octopus_system.start)
+        await octopus_system.start()
     except Exception as ex:
         _LOGGER.error("Got error when setting up Octopus Intelligent Integration: %s", ex)
         return False

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -191,7 +191,7 @@ class OctopusEnergyGraphQLClient:
     result = await session.execute(query, variable_values=params, operation_name="deleteBoostCharge")
     return result['deleteBoostCharge']
 
-  async def __async_get_accounts(session):
+  async def __async_get_accounts(self, session):
     # Execute single query
     query = gql(
     '''


### PR DESCRIPTION
Issue #28 had already been closed as [“hopefully fixed”](https://github.com/megakid/ha_octopus_intelligent/issues/28#issuecomment-1925498437), but it remained. This PR fixes that issue and another issue that got uncovered by the fix.