### PR TITLE
Prevent duplicate Octopus API call on integration load

### DIFF
--- a/custom_components/octopus_intelligent/binary_sensor.py
+++ b/custom_components/octopus_intelligent/binary_sensor.py
@@ -2,6 +2,7 @@ from gc import callbacks
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
@@ -9,12 +10,18 @@ from homeassistant.helpers.event import (
     async_track_utc_time_change
 )
 from .const import DOMAIN, OCTOPUS_SYSTEM
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.util import slugify
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     async_add_entities([
         OctopusIntelligentSlot(
             hass, 
@@ -44,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             hass, 
             hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM],
             "Octopus Intelligent Planned Dispatch Slot")
-    ], True)
+    ], False)  # False: data was already fetched by __init__.py async_setup_entry()
 
 
 class OctopusIntelligentSlot(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/octopus_intelligent/select.py
+++ b/custom_components/octopus_intelligent/select.py
@@ -5,19 +5,26 @@ from homeassistant.const import (
 from homeassistant.components.select import (
     SelectEntity,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 from .const import DOMAIN, OCTOPUS_SYSTEM, INTELLIGENT_SOC_OPTIONS, INTELLIGENT_CHARGE_TIMES
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback, HomeAssistant
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     async_add_entities([
       OctopusIntelligentTargetSoc(hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM]),
       OctopusIntelligentTargetTime(hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM])], 
-    True)
+    False)  # False: data was already fetched by __init__.py async_setup_entry()
 
 
 class OctopusIntelligentTargetSoc(CoordinatorEntity, SelectEntity):

--- a/custom_components/octopus_intelligent/sensor.py
+++ b/custom_components/octopus_intelligent/sensor.py
@@ -6,18 +6,25 @@ from homeassistant.components.sensor import (
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import (
     async_track_utc_time_change
 )
 from .const import DOMAIN, OCTOPUS_SYSTEM
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     async_add_entities([
         OctopusIntelligentNextOffpeakTime(
             hass, 
@@ -25,7 +32,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         OctopusIntelligentOffpeakEndTime(
             hass, 
             hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM]),
-    ], True)
+    ], False)  # False: data was already fetched by __init__.py async_setup_entry()
 
 
 class OctopusIntelligentNextOffpeakTime(CoordinatorEntity, SensorEntity):

--- a/custom_components/octopus_intelligent/switch.py
+++ b/custom_components/octopus_intelligent/switch.py
@@ -2,19 +2,26 @@ from gc import callbacks
 from homeassistant.components.switch import (
     SwitchEntity,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 from .const import DOMAIN, OCTOPUS_SYSTEM
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback, HomeAssistant
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
     async_add_entities([
       OctopusIntelligentBumpChargeSwitch(hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM]), 
       OctopusIntelligentSmartChargeSwitch(hass.data[DOMAIN][config_entry.entry_id][OCTOPUS_SYSTEM])], 
-    True)
+    False)  # False: data was already fetched by __init__.py async_setup_entry()
 
 class OctopusIntelligentBumpChargeSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(self, octopus_system) -> None:


### PR DESCRIPTION
While working on other PRs, I observed (through debug logging) that the Octopus GraphQL API ([async_get_combined_state](https://github.com/megakid/ha_octopus_intelligent/blob/v1.6.3/custom_components/octopus_intelligent/graphql_client.py#L24)) was called twice — one call right after the other — when the integration was loaded, e.g. when HASS was restarted.

The first call is a result of the call to `async_config_entry_first_refresh()` on the following line:
https://github.com/megakid/ha_octopus_intelligent/blob/v1.6.3/custom_components/octopus_intelligent/__init__.py#L59

The second call is a result of each platform (binary sensor, sensor, switch, select) calling `async_add_entities(..., True)`, where the `True` argument is short for `update_before_add=True`, which triggers a call chain that eventually results in calls to `async_request_refresh()` on the `DataUpdateCoordinator`:
https://github.com/home-assistant/core/blob/2024.2.5/homeassistant/helpers/update_coordinator.py#L521

This in turn calls `_debounced_refresh.async_call()`:
https://github.com/home-assistant/core/blob/2024.2.5/homeassistant/helpers/update_coordinator.py#L263

Which is a “debounced” call, meaning that, if multiple calls are made in a short period of time (I think it was a 10-second interval), only one call gets made. This way, the 4 calls from the 4 platforms (binary sensor, sensor, switch, select) get combined in a single call, which is made straight away. However, the call triggered by `async_config_entry_first_refresh()` is not subject to debouncing, so the Octopus API is hit twice.

The API call triggered by `async_config_entry_first_refresh()` is guaranteed to happen before the calls triggered by `async_add_entities(..., True)` because the latter are triggered by `async_forward_entry_setup()` on the following line:
https://github.com/megakid/ha_octopus_intelligent/blob/v1.6.3/custom_components/octopus_intelligent/__init__.py#L65

They appear in the code in this order:
```py
    await octopus_system.async_config_entry_first_refresh()        

    for component in PLATFORMS:
        hass.async_create_task(
            hass.config_entries.async_forward_entry_setup(entry, component))
```

Therefore, the conclusion is that there is no need for the platforms to request `update_before_add=True` and they could use a `False` argument instead: `async_add_entities(..., False)`. This saves an unnecessary, duplicate call to the Octopus API whenever Home Assistant restarts. Obviously I tested it to confirm that it works.

It’s not much, but the Octopus API sometimes suffers from load issues and takes 30+ seconds to reply to a query, indeed the subject of @megakid’s commit [9f45e59](https://github.com/megakid/ha_octopus_intelligent/commit/9f45e5987abdee6ddf6d1c190a61f14b7e20e513) / release v1.6.3 and issues like #30 and #31, so I reckon it’s worth it. Also, for developers like me who frequently restart HASS to test stuff, it feels reassuring that my Octopus account won’t be rate-limited or suspended because of duplicate calls.