### PR TITLE
Config flow: Fix Octopus account validation, improve error handling

### DIFF
--- a/custom_components/octopus_intelligent/config_flow.py
+++ b/custom_components/octopus_intelligent/config_flow.py
@@ -58,10 +58,7 @@ class OctopusIntelligentConfigFlowHandler(config_entries.ConfigFlow, domain=DOMA
 
         errors = {}
         try:
-            await self.hass.async_add_executor_job(
-                try_connection,
-                user_input[CONF_API_KEY],
-                user_input[CONF_ACCOUNT_ID])
+            await try_connection(user_input[CONF_API_KEY], user_input[CONF_ACCOUNT_ID])
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -17,7 +17,7 @@ class OctopusEnergyGraphQLClient:
     self._login_attempt = 0
     self._session = None
 
-  async def async_get_accounts(self):
+  async def async_get_accounts(self) -> list[str]:
     """Gets the accounts for the given API key"""
     return await self.__async_execute_with_session(self.__async_get_accounts)
 

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -191,7 +191,7 @@ class OctopusEnergyGraphQLClient:
     result = await session.execute(query, variable_values=params, operation_name="deleteBoostCharge")
     return result['deleteBoostCharge']
 
-  async def __async_get_accounts(session):
+  async def __async_get_accounts(self, session):
     # Execute single query
     query = gql(
     '''

--- a/custom_components/octopus_intelligent/graphql_util.py
+++ b/custom_components/octopus_intelligent/graphql_util.py
@@ -1,0 +1,63 @@
+"""Validation and parsing for the Octopus GraphQL API."""
+from ast import literal_eval
+from pprint import pformat
+
+from gql.transport.exceptions import TransportQueryError
+
+from .graphql_client import OctopusEnergyGraphQLClient
+
+
+class InvalidAuthError(Exception):
+    """Invalid Octopus API key or account number."""
+
+
+async def validate_octopus_account(client: OctopusEnergyGraphQLClient, account_id: str):
+    """Check that the Octopus account_id matches the authenticated API."""
+    try:
+        accounts = await client.async_get_accounts()
+    except TransportQueryError as ex:
+        msg = parse_gql_query_error(ex, "Authentication failed")
+        raise InvalidAuthError(msg) from ex
+    if account_id not in accounts:
+        raise InvalidAuthError(
+            f"Account '{account_id}' not found in accounts {accounts}"
+        )
+
+
+def parse_gql_query_error(error: TransportQueryError, default_title: str) -> str:
+    """Format a GQL JSON-like error response into something arguably readable for logging.
+
+    Sample formatted return value:
+
+    Authentication failed:
+    {'message': 'Invalid data.',
+     'path': ['obtainKrakenToken'],
+     'extensions': {'errorType': 'VALIDATION',
+                    'errorCode': 'KT-CT-1139',
+                    'errorDescription': 'Authentication failed.',
+                    'errorClass': 'VALIDATION',
+                    'validationErrors': [{'message': 'Authentication failed.',
+                                          'inputPath': ['input', 'apiKey']}]}}
+    """
+    err_str = str(error)
+    if len(err_str) > 500:  # Some protection against wild inputs
+        return err_str
+    try:
+        # Using ast.literal_eval() instead of json.loads() because the GQL
+        # response uses single quotes in object notation, and quote replacement
+        # may go wrong if the error messages include quotes.
+        obj = literal_eval(err_str)
+        if not isinstance(obj, dict):
+            return err_str
+        if "locations" in obj:
+            del obj["locations"]  # Noise
+        exts = obj.get("extensions", {})
+        title = exts.get("errorDescription", "") if isinstance(exts, dict) else ""
+        if isinstance(title, str) and len(title) > 1:
+            title = title.rstrip(".") or default_title
+        else:
+            title = default_title
+        body = pformat(obj, sort_dicts=False)
+        return f"{title}:\n{body}"
+    except Exception:  # pylint: disable=broad-except
+        return err_str

--- a/custom_components/octopus_intelligent/manifest.json
+++ b/custom_components/octopus_intelligent/manifest.json
@@ -7,5 +7,5 @@
   "codeowners": ["@megakid"],
   "iot_class": "cloud_polling",
   "config_flow": true,
-  "requirements": ["gql==3.2.0"]
+  "requirements": ["gql~=3.5.0"]
 }

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .graphql_client import OctopusEnergyGraphQLClient
+from .graphql_util import validate_octopus_account
 from .util import *
 
 _LOGGER = logging.getLogger(__name__)
@@ -173,13 +174,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
 
     async def start(self):
         _LOGGER.debug("Starting OctopusIntelligentSystem")
-        try:
-            accounts = await self.client.async_get_accounts()
-            if (self._account_id not in accounts):
-                _LOGGER.error(f"Account {self._account_id} not found in accounts {accounts}")
-                raise Exception(f"Account {self._account_id} not found in accounts {accounts}")
-        except Exception as ex:
-            _LOGGER.error(f"Authentication failed : {ex.message}. You may need to check your token or create a new app in the gardena api and use the new token.")
+        await validate_octopus_account(self.client, self._account_id)
 
     async def stop(self):
         _LOGGER.debug("Stopping OctopusIntelligentSystem")


### PR DESCRIPTION
This PR is a spin-off of other PRs and a result of my testing of the integration while working on those other PRs. Testing involved adding and removing the integration a few times, which goes through the config flow. I noticed that the config flow web UI was not displaying authentication errors when the user entered an incorrect Octopus account number or API key. After this PR, “Invalid Authentication” is displayed in red on the form as shown in the following screenshot:

<img width="395" alt="Octopus Intelligent Invalid Auth" src="https://github.com/megakid/ha_octopus_intelligent/assets/15091591/072067cc-94ed-47e3-8828-b37a9de04d4c">

It’s a terse two-word error message, but it takes advantage of Home Assistant’s standard error message localisation in multiple languages. Anyway, I just made it work the way I understood it was supposed to. :-)

While working on PR #38, I noticed that the body of `OctopusIntelligentSystem.start()` was copy-and-paste-kind-of-similar to the `try_connection()` function in `config_flow.py`, and had the same bugs. So I refactored them to call a common function (in a new `graphql_util.py` file) and fixed some issues there.

See more details in other comments.