### PR TITLE
Replace async_timeout library and simplify platform setup loop

### DIFF
--- a/custom_components/octopus_intelligent/__init__.py
+++ b/custom_components/octopus_intelligent/__init__.py
@@ -60,9 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     #hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, lambda event: octopus_system.stop())
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.debug("Octopus Intelligent System component setup finished")
     return True

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -151,7 +151,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
     async def async_set_target_soc(self, target_soc: int):
         target_time_str = self.get_target_time()
         if target_time_str is None:
-            _LOGGER.warn("Octopus Intelligent System could not set target SOC because data is available yet")
+            _LOGGER.warn("Octopus Intelligent System could not set target SOC because data is not available yet")
             return
         target_time = to_hours_after_midnight(target_time_str)
         await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc)
@@ -160,7 +160,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
     async def async_set_target_time(self, target_time: str):
         target_soc = self.get_target_soc()
         if (target_soc is None):
-            _LOGGER.warn("Octopus Intelligent System could not set target time because data is available yet")
+            _LOGGER.warn("Octopus Intelligent System could not set target time because data is not available yet")
             return
         target_time = to_hours_after_midnight(target_time)
         await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc)

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -1,7 +1,7 @@
 """Support for Octopus Intelligent Tariff in the UK."""
 from datetime import timedelta, datetime, timezone
+import asyncio
 import logging
-import async_timeout
 
 import homeassistant.util.dt as dt_util
 
@@ -48,7 +48,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(90):
+            async with asyncio.timeout(90):
                 return await self.client.async_get_combined_state(self._account_id)
         # except ApiAuthError as err:
         #     # Raising ConfigEntryAuthFailed will cancel future updates


### PR DESCRIPTION
[`async_timeout`](https://pypi.org/project/async-timeout/) is a third-party library installed through PyPI / `pip install`. It was written in 2016, around the time when Python 3.6 was released. At that time, Python’s `asyncio` built-in module had a `wait_for()` function but not a `timeout()` function. In 2022, Python 3.11 was released including a drop-in replacement for the `async_timeout` library through the built-in [`asyncio.timeout()`](https://docs.python.org/3.11/library/asyncio-task.html#asyncio.timeout) function. Other things equal, a built-in function is preferable to a third-party PyPI library.

Meanwhile, Home Assistant dropped support for Python versions 3.10 and older in HASS version 2023.8.0 (Aug 2023). It now requires Python versions 3.11 or 3.12.

Also, the `async_timeout` library is not being declared as a dependency in this integration’s [`manifest.json`](https://github.com/megakid/ha_octopus_intelligent/blob/v1.6.3/custom_components/octopus_intelligent/manifest.json) file, so Home Assistant is not making sure that `async_timeout` is installed alongside this integration. It has been working so far because other common Home Assistant integrations still declare `async_timeout` as a dependency.

This PR also proposes a simplification to the platform setup loop using the [`async_forward_entry_setups()`](https://github.com/home-assistant/core/blob/2024.2.5/homeassistant/config_entries.py#L1566) function added to Home Assistant 2022.8.0 (Aug 2022), and a couple of log message amendments.