### PR TITLE
Fix ImportError: cannot import name 'override' from 'typing' (Python 3.11)

### DIFF
--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -1,6 +1,6 @@
 """Support for Octopus Intelligent Tariff in the UK."""
 from datetime import timedelta, datetime, timezone
-from typing import Any, override
+from typing import Any
 import asyncio
 import logging
 
@@ -43,7 +43,6 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
     def account_id(self):
         return self._account_id
 
-    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint.
 


### PR DESCRIPTION
Fixes #43.

PR #37 introduced an [`@override`](https://docs.python.org/3/library/typing.html#typing.override) code annotation that while correct, is only available with Python 3.12 and later. But Home Assistant, and this integration, currently still support Python 3.11. This PR thus removes that annotation. (The annotation is only a development aid and does change the code’s functionality.)

Tested with Home Assistant 2024.1.6 which is the last container release shipped with Python 3.11.