### PR TITLE
Add config screen for addon options

### DIFF
--- a/custom_components/octopus_intelligent/__init__.py
+++ b/custom_components/octopus_intelligent/__init__.py
@@ -66,6 +66,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Octopus Intelligent config entry."""
+    _LOGGER.debug("Unloading Octopus Intelligent System component")
+    
+    # Unload platforms
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    
+    if unload_ok:
+        # Clean up the system instance
+        if entry.entry_id in hass.data[DOMAIN]:
+            octopus_system: OctopusIntelligentSystem = (
+                hass.data[DOMAIN][entry.entry_id].get(OCTOPUS_SYSTEM)
+            )
+            if octopus_system:
+                try:
+                    await octopus_system.async_remove_entry()
+                except Exception as ex:  # pylint: disable=broad-exception-caught
+                    _LOGGER.error("Error during unload: %s", ex)
+            
+            # Remove the entry data
+            hass.data[DOMAIN].pop(entry.entry_id)
+    
+    _LOGGER.debug("Octopus Intelligent System component unload finished")
+    return unload_ok
+
+
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Called when the config entry is removed (the integration is deleted)."""
     octopus_system: OctopusIntelligentSystem = (

--- a/custom_components/octopus_intelligent/config_flow.py
+++ b/custom_components/octopus_intelligent/config_flow.py
@@ -83,43 +83,79 @@ class OctopusIntelligentConfigFlowHandler(config_entries.ConfigFlow, domain=DOMA
                 CONF_OFFPEAK_END: user_input[CONF_OFFPEAK_END],
             })
 
-    # @staticmethod
-    # @callback
-    # def async_get_options_flow(config_entry):
-    #     return GardenaSmartSystemOptionsFlowHandler(config_entry)
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Return the options flow handler."""
+        return OctopusIntelligentOptionsFlowHandler(config_entry)
 
 
-# class GardenaSmartSystemOptionsFlowHandler(config_entries.OptionsFlow):
-#     def __init__(self, config_entry):
-#         """Initialize Gardena Smart Sytem options flow."""
-#         self.config_entry = config_entry
+class OctopusIntelligentOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for Octopus Intelligent integration."""
+    
+    def __init__(self, config_entry):
+        """Initialize Octopus Intelligent options flow."""
+        self.config_entry = config_entry
 
-#     async def async_step_init(self, user_input=None):
-#         """Manage the options."""
-#         return await self.async_step_user()
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_user()
 
-#     async def async_step_user(self, user_input=None):
-#         """Handle a flow initialized by the user."""
-#         errors = {}
-#         if user_input is not None:
-#             # TODO: Validate options (min, max values)
-#             return self.async_create_entry(title="", data=user_input)
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+        
+        if user_input is not None:
+            # Validate the API key and account ID if they were changed
+            try:
+                await try_connection(user_input[CONF_API_KEY], user_input[CONF_ACCOUNT_ID])
+                
+                # Update the config entry data with new values
+                new_data = {
+                    CONF_ID: self.config_entry.data.get(CONF_ID),
+                    CONF_API_KEY: user_input[CONF_API_KEY],
+                    CONF_ACCOUNT_ID: user_input[CONF_ACCOUNT_ID],
+                    CONF_OFFPEAK_START: user_input[CONF_OFFPEAK_START],
+                    CONF_OFFPEAK_END: user_input[CONF_OFFPEAK_END],
+                }
+                
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=new_data
+                )
+                
+                return self.async_create_entry(title="", data={})
+                
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.error(ex)
+                if isinstance(ex, InvalidAuthError):
+                    errors["base"] = "invalid_auth"
+                else:
+                    errors["base"] = "unknown"
 
-#         fields = OrderedDict()
-#         fields[vol.Optional(
-#             CONF_MOWER_DURATION,
-#             default=self.config_entry.options.get(
-#                 CONF_MOWER_DURATION, DEFAULT_MOWER_DURATION))] = cv.positive_int
-#         fields[vol.Optional(
-#             CONF_SMART_IRRIGATION_DURATION,
-#             default=self.config_entry.options.get(
-#                 CONF_SMART_IRRIGATION_DURATION, DEFAULT_SMART_IRRIGATION_DURATION))] = cv.positive_int
-#         fields[vol.Optional(
-#             CONF_SMART_WATERING_DURATION,
-#             default=self.config_entry.options.get(
-#                 CONF_SMART_WATERING_DURATION, DEFAULT_SMART_WATERING_DURATION))] = cv.positive_int
+        # Get current values from config entry
+        fields = OrderedDict()
+        fields[vol.Required(
+            CONF_API_KEY,
+            default=self.config_entry.data.get(CONF_API_KEY, "")
+        )] = str
+        fields[vol.Required(
+            CONF_ACCOUNT_ID,
+            default=self.config_entry.data.get(CONF_ACCOUNT_ID, "")
+        )] = str
+        fields[vol.Required(
+            CONF_OFFPEAK_START,
+            default=self.config_entry.data.get(CONF_OFFPEAK_START, CONF_OFFPEAK_START_DEFAULT)
+        )] = vol.In(INTELLIGENT_24HR_TIMES)
+        fields[vol.Required(
+            CONF_OFFPEAK_END,
+            default=self.config_entry.data.get(CONF_OFFPEAK_END, CONF_OFFPEAK_END_DEFAULT)
+        )] = vol.In(INTELLIGENT_24HR_TIMES)
 
-#         return self.async_show_form(step_id="user", data_schema=vol.Schema(fields), errors=errors)
+        return self.async_show_form(
+            step_id="user", 
+            data_schema=vol.Schema(fields), 
+            errors=errors
+        )
 
 
 async def try_connection(api_key: str, account_id: str):

--- a/custom_components/octopus_intelligent/strings.json
+++ b/custom_components/octopus_intelligent/strings.json
@@ -23,13 +23,22 @@
     }
   },
   "options": {
+    "error": {
+      "cannot_connect": "Failed to connect, please try again.",
+      "invalid_auth": "Invalid authentication.",
+      "too_many_requests": "Too many requests, retry later.",
+      "unknown": "Unexpected error."
+    },
     "step": {
       "user": {
+        "description": "Update your Octopus Intelligent configuration settings.",
         "data": {
+          "api_key": "API Key",
+          "account_id": "Account Id",
           "offpeak_start": "Offpeak Start (normally 23:30)",
           "offpeak_end": "Offpeak End (normally 05:30)"
         },
-        "title": "Octopus Intelligent - Options"
+        "title": "Octopus Intelligent - Configuration"
       }
     }
   }


### PR DESCRIPTION
An options flow was implemented for the Octopus Intelligent integration to allow users to modify installation parameters without reinstallation.

*   The `OctopusIntelligentOptionsFlowHandler` class was enabled and implemented in `custom_components/octopus_intelligent/config_flow.py`. This allows users to modify the API Key, Account ID, Offpeak Start, and Offpeak End times.
*   Credential validation was added to the options flow, utilizing `try_connection` to ensure API connectivity and provide error feedback.
*   An `async_unload_entry` function was added to `custom_components/octopus_intelligent/__init__.py`. This function ensures proper cleanup of the integration's resources when configuration changes trigger an automatic reload via `hass.config_entries.async_update_entry`.
*   `custom_components/octopus_intelligent/strings.json` was updated to include UI text, labels, and error messages for the new options flow, enhancing user experience.

These changes enable seamless configuration updates, preserving entity IDs and historical data.