### PR TITLE
Match Octopus UIs options for charge levels

### DIFF
--- a/custom_components/octopus_intelligent/const.py
+++ b/custom_components/octopus_intelligent/const.py
@@ -29,4 +29,4 @@ CONF_OFFPEAK_END_DEFAULT: Final = "05:30"
 INTELLIGENT_MINS_PAST_HOURS: Final = [0, 30]
 INTELLIGENT_24HR_TIMES: Final = [f"{hour:02}:{mins:02}" for hour in range(24) for mins in INTELLIGENT_MINS_PAST_HOURS]
 INTELLIGENT_CHARGE_TIMES: Final = [f"{hour:02}:{mins:02}" for hour in range(4, 12) for mins in INTELLIGENT_MINS_PAST_HOURS][:-1]
-INTELLIGENT_SOC_OPTIONS: Final = list(range(10, 105, 5))
+INTELLIGENT_SOC_OPTIONS: Final = list(range(10, 101))


### PR DESCRIPTION
Rather than increments of 5, the octopus UI starts at 10 and counts all the way to 100. By matching this, automations can automatically set a desired charge amount to get their vehicle charged to a target percentage.