### PR TITLE
Allow device selection and multiple installations

### DIFF
--- a/custom_components/octopus_intelligent/__init__.py
+++ b/custom_components/octopus_intelligent/__init__.py
@@ -16,6 +16,7 @@ from .const import(
     OCTOPUS_SYSTEM,
 
     CONF_ACCOUNT_ID,
+    CONF_DEVICE_ID,
     CONF_OFFPEAK_START,
     CONF_OFFPEAK_END
 )
@@ -42,7 +43,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         api_key=entry.data[CONF_API_KEY],
         account_id=entry.data[CONF_ACCOUNT_ID],
         off_peak_start=to_timedelta(entry.data[CONF_OFFPEAK_START]),
-        off_peak_end=to_timedelta(entry.data[CONF_OFFPEAK_END])
+        off_peak_end=to_timedelta(entry.data[CONF_OFFPEAK_END]),
+        device_id=entry.data.get(CONF_DEVICE_ID)
     )
 
     try:

--- a/custom_components/octopus_intelligent/binary_sensor.py
+++ b/custom_components/octopus_intelligent/binary_sensor.py
@@ -57,8 +57,14 @@ async def async_setup_entry(
 class OctopusIntelligentSlot(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, hass, octopus_system, name : str, store_attributes : bool = False, look_ahead_mins : int = 0) -> None:
         """Initialize the binary sensor."""
-        self._name = name
-        self._unique_id = slugify(name)
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"{name}{device_suffix}"
+        
+        if octopus_system.device_id:
+            self._unique_id = slugify(f"{name}_{octopus_system.device_id}")
+        else:
+            self._unique_id = slugify(name)
+            
         self._octopus_system = octopus_system
         self._store_attributes = store_attributes
         self._look_ahead_mins = look_ahead_mins
@@ -133,8 +139,14 @@ class OctopusIntelligentSlot(CoordinatorEntity, BinarySensorEntity):
 class OctopusIntelligentPlannedDispatchSlot(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, hass, octopus_system, name : str) -> None:
         """Initialize the binary sensor."""
-        self._name = name
-        self._unique_id = slugify(name)
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"{name}{device_suffix}"
+        
+        if octopus_system.device_id:
+            self._unique_id = slugify(f"{name}_{octopus_system.device_id}")
+        else:
+             self._unique_id = slugify(name)
+             
         self._octopus_system = octopus_system
         self._attributes = {}
         self._is_on = self._octopus_system.is_off_peak_charging_now()

--- a/custom_components/octopus_intelligent/config_flow.py
+++ b/custom_components/octopus_intelligent/config_flow.py
@@ -17,6 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from .const import (
     DOMAIN,
     CONF_ACCOUNT_ID,
+    CONF_DEVICE_ID,
     CONF_OFFPEAK_START,
     CONF_OFFPEAK_START_DEFAULT,
     CONF_OFFPEAK_END,
@@ -68,20 +69,72 @@ class OctopusIntelligentConfigFlowHandler(config_entries.ConfigFlow, domain=DOMA
                 errors["base"] = "unknown"
             return await self._show_setup_form(errors)
 
-        unique_id = user_input[CONF_ACCOUNT_ID]
+        self.api_key = user_input[CONF_API_KEY]
+        self.account_id = user_input[CONF_ACCOUNT_ID]
+        self.offpeak_start = user_input[CONF_OFFPEAK_START]
+        self.offpeak_end = user_input[CONF_OFFPEAK_END]
 
+        return await self.async_step_device()
+
+    async def async_step_device(self, user_input=None):
+        """Handle the device selection step."""
+        if user_input is None:
+            client = OctopusEnergyGraphQLClient(self.api_key)
+            try:
+                devices = await client.async_get_devices(self.account_id)
+            except Exception as ex:
+                _LOGGER.error("Error fetching devices: %s", ex)
+                return self.async_abort(reason="cannot_fetch_devices")
+
+            if not devices:
+                return self.async_abort(reason="no_devices_found")
+            
+            self.devices_map = {
+                d["id"]: f"{d.get('vehicleMake', 'Unknown')} {d.get('vehicleModel', 'Vehicle')} ({d['id']})"
+                for d in devices
+            }
+            
+            # If only one device, auto-select it
+            if len(self.devices_map) == 1:
+                self.device_id = list(self.devices_map.keys())[0]
+                return await self.async_step_final()
+
+            return self.async_show_form(
+                step_id="device",
+                data_schema=vol.Schema({
+                    vol.Required(CONF_DEVICE_ID): vol.In(self.devices_map)
+                })
+            )
+
+        self.device_id = user_input[CONF_DEVICE_ID]
+        return await self.async_step_final()
+
+    async def async_step_final(self):
+        """Create the config entry."""
+        unique_id = self.device_id
+        
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
+        
+        # Determine title
+        title = ""
+        if hasattr(self, 'devices_map') and self.device_id in self.devices_map:
+            title = self.devices_map[self.device_id]
+        else:
+             # Fallback if devices_map is missing (should not happen normally)
+             title = f"Device {self.device_id}"
 
         return self.async_create_entry(
-            title="",
+            title=title,
             data={
                 CONF_ID: unique_id,
-                CONF_API_KEY: user_input[CONF_API_KEY],
-                CONF_ACCOUNT_ID: user_input[CONF_ACCOUNT_ID],
-                CONF_OFFPEAK_START: user_input[CONF_OFFPEAK_START],
-                CONF_OFFPEAK_END: user_input[CONF_OFFPEAK_END],
-            })
+                CONF_API_KEY: self.api_key,
+                CONF_ACCOUNT_ID: self.account_id,
+                CONF_OFFPEAK_START: self.offpeak_start,
+                CONF_OFFPEAK_END: self.offpeak_end,
+                CONF_DEVICE_ID: self.device_id
+            }
+        )
 
     @staticmethod
     @callback
@@ -117,6 +170,7 @@ class OctopusIntelligentOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_ACCOUNT_ID: user_input[CONF_ACCOUNT_ID],
                     CONF_OFFPEAK_START: user_input[CONF_OFFPEAK_START],
                     CONF_OFFPEAK_END: user_input[CONF_OFFPEAK_END],
+                    CONF_DEVICE_ID: self.config_entry.data.get(CONF_DEVICE_ID),
                 }
                 
                 self.hass.config_entries.async_update_entry(

--- a/custom_components/octopus_intelligent/const.py
+++ b/custom_components/octopus_intelligent/const.py
@@ -7,6 +7,7 @@ OCTOPUS_SYSTEM: Final = "octopus_system"
 INTELLIGENT_DATA: Final = "intelligent_data"
 
 CONF_ACCOUNT_ID: Final = "account_id"
+CONF_DEVICE_ID: Final = "device_id"
 
 ATTR_NAME = "name"
 ATTR_ACTIVITY = "activity"

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -21,6 +21,10 @@ class OctopusEnergyGraphQLClient:
     """Gets the accounts for the given API key"""
     return await self.__async_execute_with_session(self.__async_get_accounts)
 
+  async def async_get_devices(self, account_id: str):
+    """Gets the devices for the given account"""
+    return await self.__async_execute_with_session(lambda session: self.__async_get_devices(session, account_id))
+
   async def async_get_combined_state(self, account_id: str):
     """Gets the state for the given account"""
     return await self.__async_execute_with_session(lambda session: self.__async_get_combined_state(session, account_id))
@@ -29,13 +33,14 @@ class OctopusEnergyGraphQLClient:
     """Gets the charging preferences for the given account"""
     return await self.__async_execute_with_session(lambda session: self.__async_get_charge_preferences(session, account_id))
 
-  async def async_set_charge_preferences(self, account_id: str, readyByHoursAfterMidnight: float, targetSocPercent: int):
+  async def async_set_charge_preferences(self, account_id: str, readyByHoursAfterMidnight: float, targetSocPercent: int, device_id: str = None):
     """Sets the charging preferences for the given account"""
     return await self.__async_execute_with_session(
       lambda session: self.__async_set_charge_preferences(session, 
         account_id, 
         readyByHoursAfterMidnight, 
-        targetSocPercent))
+        targetSocPercent,
+        device_id))
     
   async def async_trigger_boost_charge(self, account_id: str):
     """Triggers a boost charge for the given account"""
@@ -46,13 +51,13 @@ class OctopusEnergyGraphQLClient:
     return await self.__async_execute_with_session(lambda session: self.__async_cancel_boost_charge(session, account_id))
 
 
-  async def async_suspend_smart_charging(self, account_id: str):
+  async def async_suspend_smart_charging(self, account_id: str, device_id: str = None):
     """Suspends smart charging for the given account"""
-    return await self.__async_execute_with_session(lambda session: self.__async_suspend_smart_charging(session, account_id))
+    return await self.__async_execute_with_session(lambda session: self.__async_suspend_smart_charging(session, account_id, device_id))
 
-  async def async_resume_smart_charging(self, account_id: str):
+  async def async_resume_smart_charging(self, account_id: str, device_id: str = None):
     """Resumes smart charging for the given account"""
-    return await self.__async_execute_with_session(lambda session: self.__async_resume_smart_charging(session, account_id))
+    return await self.__async_execute_with_session(lambda session: self.__async_resume_smart_charging(session, account_id, device_id))
 
   async def async_get_device_info(self, account_id: str):
     """Gets the device info for the given account"""
@@ -120,7 +125,7 @@ class OctopusEnergyGraphQLClient:
       except Exception as e:
         raise e
 
-  async def __async_set_charge_preferences(self, session, account_id: str, readyByHoursAfterMidnight: float, targetSocPercent: int):
+  async def __async_set_charge_preferences(self, session, account_id: str, readyByHoursAfterMidnight: float, targetSocPercent: int, device_id: str = None):
     """Sets the charging preferences for the given account"""
     # round up to nearest 5
     targetSocPercent = 5 * math.ceil(round(targetSocPercent) / 5)
@@ -139,8 +144,10 @@ class OctopusEnergyGraphQLClient:
 
     targetTime = f"{readyByHoursAfterMidnightHours:02}:{readyByHoursAfterMidnightMinutes:02}"
 
-    # Retrieve device id for the account
-    device_id = await self.__async_get_device_id(session, account_id)
+    # Retrieve device id for the account if not provided
+    if device_id is None:
+      device_id = await self.__async_get_device_id(session, account_id)
+
     if device_id is None:
       raise Exception('Failed to find intelligent device id for account')
 
@@ -319,6 +326,32 @@ class OctopusEnergyGraphQLClient:
     return result
 
 
+  async def __async_get_devices(self, session, account_id: str):
+    """Retrieve all intelligent devices for account."""
+    query = gql(
+    '''
+      query getDevices($accountNumber: String!) {
+        devices(accountNumber: $accountNumber) {
+          id
+          deviceType
+          status { current }
+          vehicleMake
+          vehicleModel
+        }
+      }
+    ''')
+
+    params = {"accountNumber": account_id}
+    result = await session.execute(query, variable_values=params, operation_name="getDevices")
+    devices = result['devices'] if result is not None and 'devices' in result else []
+    
+    valid_devices = []
+    for device in devices:
+        if device is not None and device.get('deviceType') == 'ELECTRIC_VEHICLES' and device.get('status', {}).get('current') == 'LIVE':
+             valid_devices.append(device)
+             
+    return valid_devices
+
   async def __async_get_device_id(self, session, account_id: str):
     """Retrieve the new device id for intelligent device for use with mutations."""
     # Prefer new devices query, fallback to krakenflexDeviceId
@@ -350,10 +383,12 @@ class OctopusEnergyGraphQLClient:
 
 
 
-  async def __async_suspend_smart_charging(self, session, account_id: str):
+  async def __async_suspend_smart_charging(self, session, account_id: str, device_id: str = None):
     """Suspends smart charging for the given account"""
-    # Retrieve device id for the account
-    device_id = await self.__async_get_device_id(session, account_id)
+    # Retrieve device id for the account if not provided
+    if device_id is None:
+        device_id = await self.__async_get_device_id(session, account_id)
+        
     if device_id is None:
       raise Exception('Failed to find intelligent device id for account')
 
@@ -372,10 +407,12 @@ class OctopusEnergyGraphQLClient:
     return result['updateDeviceSmartControl']
 
 
-  async def __async_resume_smart_charging(self, session, account_id: str):
+  async def __async_resume_smart_charging(self, session, account_id: str, device_id: str = None):
     """Resumes smart charging for the given account"""
-    # Retrieve device id for the account
-    device_id = await self.__async_get_device_id(session, account_id)
+    # Retrieve device id for the account if not provided
+    if device_id is None:
+        device_id = await self.__async_get_device_id(session, account_id)
+        
     if device_id is None:
       raise Exception('Failed to find intelligent device id for account')
 

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -25,9 +25,9 @@ class OctopusEnergyGraphQLClient:
     """Gets the devices for the given account"""
     return await self.__async_execute_with_session(lambda session: self.__async_get_devices(session, account_id))
 
-  async def async_get_combined_state(self, account_id: str):
+  async def async_get_combined_state(self, account_id: str, device_id: str = None):
     """Gets the state for the given account"""
-    return await self.__async_execute_with_session(lambda session: self.__async_get_combined_state(session, account_id))
+    return await self.__async_execute_with_session(lambda session: self.__async_get_combined_state(session, account_id, device_id))
 
   async def async_get_charge_preferences(self, account_id: str):
     """Gets the charging preferences for the given account"""
@@ -275,8 +275,111 @@ class OctopusEnergyGraphQLClient:
     result = await session.execute(query, variable_values=params, operation_name="registeredKrakenflexDevice")
     return result['registeredKrakenflexDevice']
 
-  async def __async_get_combined_state(self, session, account_id: str):
+  async def __async_get_combined_state(self, session, account_id: str, device_id: str = None):
     """Get the user's account state"""
+    
+    if device_id:
+        # Use new device-specific query
+        query = gql(
+        '''
+        query getDeviceSpecificData($accountNumber: String!, $deviceId: ID!) {
+            devices(accountNumber: $accountNumber, deviceId: $deviceId) {
+                id
+                provider
+                deviceType
+                status { 
+                    current 
+                    isSuspended
+                    suspended
+                }
+                ... on SmartFlexVehicle {
+                    vehicleMake: make
+                    vehicleModel: model
+                    vehicleBatterySizeInKwh: batterySize
+                    chargingPreferences {
+                        weekdayTargetTime
+                        weekdayTargetSoc
+                        weekendTargetTime
+                        weekendTargetSoc
+                    }
+                }
+                ... on SmartFlexChargePoint {
+                    chargePointMake: make
+                    chargePointModel: model
+                    chargePointPowerInKw: powerInKw
+                    chargingPreferences {
+                        weekdayTargetTime
+                        weekdayTargetSoc
+                        weekendTargetTime
+                        weekendTargetSoc
+                    }
+                }
+            }
+            flexPlannedDispatches(deviceId: $deviceId) {
+                startDtUtc: start
+                endDtUtc: end
+                chargeKwh: energyAddedKwh
+                source: type
+            }
+            completedDispatches(accountNumber: $accountNumber) {
+                startDtUtc: start
+                endDtUtc: end
+                chargeKwh: delta
+                meta { 
+                    source
+                    location
+                }
+            }
+        }
+        ''')
+        
+        params = {"accountNumber": account_id, "deviceId": device_id}
+        result = await session.execute(query, variable_values=params, operation_name="getDeviceSpecificData")
+        
+        # Transform to match old structure
+        devices = result.get('devices', [])
+        device = devices[0] if devices else {}
+        
+        # Try to find charging preferences in fragments
+        charging_preferences = device.get('chargingPreferences', {})
+
+        # Map to registeredKrakenflexDevice format
+        registered_device = {
+            "krakenflexDeviceId": device.get('id'),
+            "provider": device.get('provider'),
+            "vehicleMake": device.get('vehicleMake'),
+            "vehicleModel": device.get('vehicleModel'),
+            "vehicleBatterySizeInKwh": device.get('vehicleBatterySizeInKwh'),
+            "chargePointMake": device.get('chargePointMake'),
+            "chargePointModel": device.get('chargePointModel'),
+            "chargePointPowerInKw": device.get('chargePointPowerInKw'),
+            "status": device.get('status', {}).get('current'),
+            "suspended": device.get('status', {}).get('isSuspended', device.get('status', {}).get('suspended')),
+            "hasToken": True, # Assumption
+            "createdAt": None # Not available in this query
+        }
+
+        # Map flexPlannedDispatches to plannedDispatches format
+        planned_dispatches = []
+        for disp in result.get('flexPlannedDispatches', []):
+            planned_dispatches.append({
+                "startDtUtc": disp.get('startDtUtc'),
+                "endDtUtc": disp.get('endDtUtc'),
+                "chargeKwh": disp.get('chargeKwh'),
+                "meta": {
+                    "source": disp.get('source'),
+                    "location": None 
+                }
+            })
+
+        return {
+            "vehicleChargingPreferences": charging_preferences,
+            "registeredKrakenflexDevice": registered_device,
+            "plannedDispatches": planned_dispatches,
+            "completedDispatches": result.get('completedDispatches', [])
+        }
+
+    # Fallback to old query if no device_id
     query = gql(
     '''
         query getCombinedData($accountNumber: String!) {
@@ -335,8 +438,15 @@ class OctopusEnergyGraphQLClient:
           id
           deviceType
           status { current }
-          vehicleMake
-          vehicleModel
+          
+          ... on SmartFlexVehicle {
+            vehicleMake: make
+            vehicleModel: model
+          }
+          ... on SmartFlexChargePoint {
+            chargePointMake: make
+            chargePointModel: model
+          }
         }
       }
     ''')
@@ -348,6 +458,11 @@ class OctopusEnergyGraphQLClient:
     valid_devices = []
     for device in devices:
         if device is not None and device.get('deviceType') == 'ELECTRIC_VEHICLES' and device.get('status', {}).get('current') == 'LIVE':
+             # Normalize make/model
+             make = device.get('vehicleMake') or device.get('chargePointMake') or 'Unknown'
+             model = device.get('vehicleModel') or device.get('chargePointModel') or 'Vehicle'
+             device['vehicleMake'] = make
+             device['vehicleModel'] = model
              valid_devices.append(device)
              
     return valid_devices

--- a/custom_components/octopus_intelligent/graphql_client.py
+++ b/custom_components/octopus_intelligent/graphql_client.py
@@ -42,13 +42,13 @@ class OctopusEnergyGraphQLClient:
         targetSocPercent,
         device_id))
     
-  async def async_trigger_boost_charge(self, account_id: str):
+  async def async_trigger_boost_charge(self, account_id: str, device_id: str = None):
     """Triggers a boost charge for the given account"""
-    return await self.__async_execute_with_session(lambda session: self.__async_trigger_boost_charge(session, account_id))
+    return await self.__async_execute_with_session(lambda session: self.__async_trigger_boost_charge(session, account_id, device_id))
     
-  async def async_cancel_boost_charge(self, account_id: str):
+  async def async_cancel_boost_charge(self, account_id: str, device_id: str = None):
     """Cancels the boost charge for the given account"""
-    return await self.__async_execute_with_session(lambda session: self.__async_cancel_boost_charge(session, account_id))
+    return await self.__async_execute_with_session(lambda session: self.__async_cancel_boost_charge(session, account_id, device_id))
 
 
   async def async_suspend_smart_charging(self, account_id: str, device_id: str = None):
@@ -174,41 +174,51 @@ class OctopusEnergyGraphQLClient:
     result = await session.execute(query, variable_values=params, operation_name="setDevicePreferences")
     return result['setDevicePreferences']
     
-  async def __async_trigger_boost_charge(self, session, account_id: str):
+  async def __async_trigger_boost_charge(self, session, account_id: str, device_id: str = None):
     """Triggers a boost charge for the given account"""
-    # Execute single query
-    query = gql(
-    '''
-      mutation triggerBoostCharge($accountNumber: String!) {
-        triggerBoostCharge(input: { accountNumber: $accountNumber }) {
-          krakenflexDevice {
-            krakenflexDeviceId
-          }
-        }
-      }
-    ''')
-
-    params = {"accountNumber": account_id}
-    result = await session.execute(query, variable_values=params, operation_name="triggerBoostCharge")
-    return result['triggerBoostCharge']
+    # Retrieve device id for the account if not provided
+    if device_id is None:
+        device_id = await self.__async_get_device_id(session, account_id)
         
-  async def __async_cancel_boost_charge(self, session, account_id: str):
-    """Cancels any boost charge currently in progress for the given account"""
-    # Execute single query
+    if device_id is None:
+      raise Exception('Failed to find intelligent device id for account')
+
+    # Execute single query using new mutation
     query = gql(
     '''
-      mutation deleteBoostCharge($accountNumber: String!) {
-        deleteBoostCharge(input: { accountNumber: $accountNumber }) {
-          krakenflexDevice {
-            krakenflexDeviceId
-          }
+      mutation updateBoostCharge($deviceId: ID!) {
+        updateBoostCharge(input: { deviceId: $deviceId, action: BOOST }) {
+          id
         }
       }
     ''')
 
-    params = {"accountNumber": account_id}
-    result = await session.execute(query, variable_values=params, operation_name="deleteBoostCharge")
-    return result['deleteBoostCharge']
+    params = {"deviceId": device_id}
+    result = await session.execute(query, variable_values=params, operation_name="updateBoostCharge")
+    return result['updateBoostCharge']
+        
+  async def __async_cancel_boost_charge(self, session, account_id: str, device_id: str = None):
+    """Cancels any boost charge currently in progress for the given account"""
+    # Retrieve device id for the account if not provided
+    if device_id is None:
+        device_id = await self.__async_get_device_id(session, account_id)
+        
+    if device_id is None:
+      raise Exception('Failed to find intelligent device id for account')
+
+    # Execute single query using new mutation
+    query = gql(
+    '''
+      mutation updateBoostCharge($deviceId: ID!) {
+        updateBoostCharge(input: { deviceId: $deviceId, action: CANCEL }) {
+          id
+        }
+      }
+    ''')
+
+    params = {"deviceId": device_id}
+    result = await session.execute(query, variable_values=params, operation_name="updateBoostCharge")
+    return result['updateBoostCharge']
 
   async def __async_get_accounts(self, session):
     # Execute single query

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -244,9 +244,9 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
         await self.async_refresh()
 
     async def async_start_boost_charge(self):
-        await self.client.async_trigger_boost_charge(self._account_id)
+        await self.client.async_trigger_boost_charge(self._account_id, self._device_id)
     async def async_cancel_boost_charge(self):
-        await self.client.async_cancel_boost_charge(self._account_id)
+        await self.client.async_cancel_boost_charge(self._account_id, self._device_id)
 
     async def async_remove_entry(self):
         """Called when the integration (config entry) is removed from Home Assistant."""

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -19,7 +19,7 @@ from .util import *
 _LOGGER = logging.getLogger(__name__)
 
 class OctopusIntelligentSystem(DataUpdateCoordinator):
-    def __init__(self, hass, *, api_key, account_id, off_peak_start, off_peak_end):
+    def __init__(self, hass, *, api_key, account_id, off_peak_start, off_peak_end, device_id=None):
         super().__init__(
             hass,
             _LOGGER,
@@ -31,6 +31,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
         self._hass = hass
         self._api_key = api_key
         self._account_id = account_id
+        self._device_id = device_id
 
         self._off_peak_start = off_peak_start
         self._off_peak_end = off_peak_end
@@ -42,6 +43,10 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
     @property
     def account_id(self):
         return self._account_id
+
+    @property
+    def device_id(self):
+        return self._device_id
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint.
@@ -132,9 +137,9 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
     def is_smart_charging_enabled(self):
         return not self.data.get('registeredKrakenflexDevice', {}).get('suspended', False)
     async def async_suspend_smart_charging(self):
-        await self.client.async_suspend_smart_charging(self._account_id)
+        await self.client.async_suspend_smart_charging(self._account_id, self._device_id)
     async def async_resume_smart_charging(self):
-        await self.client.async_resume_smart_charging(self._account_id)
+        await self.client.async_resume_smart_charging(self._account_id, self._device_id)
 
     def is_boost_charging_now(self):
         return self.is_charging_now('bump-charge')
@@ -226,7 +231,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
             _LOGGER.warn("Octopus Intelligent System could not set target SOC because data is not available yet")
             return
         target_time = to_hours_after_midnight(target_time_str)
-        await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc)
+        await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc, self._device_id)
         await self.async_refresh()
 
     async def async_set_target_time(self, target_time: str):
@@ -235,7 +240,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
             _LOGGER.warn("Octopus Intelligent System could not set target time because data is not available yet")
             return
         target_time = to_hours_after_midnight(target_time)
-        await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc)
+        await self.client.async_set_charge_preferences(self._account_id, target_time, target_soc, self._device_id)
         await self.async_refresh()
 
     async def async_start_boost_charge(self):

--- a/custom_components/octopus_intelligent/octopus_intelligent_system.py
+++ b/custom_components/octopus_intelligent/octopus_intelligent_system.py
@@ -92,7 +92,7 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(90):
-                data = await self.client.async_get_combined_state(self._account_id)
+                data = await self.client.async_get_combined_state(self._account_id, self._device_id)
                 self._update_planned_dispatch_sources(data)
                 return data
         # except ApiAuthError as err:
@@ -182,8 +182,8 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
 
         for state in self.data.get('plannedDispatches', []):
             if state.get('meta', {}).get('source', '') == 'smart-charge':
-                startUtc = datetime.strptime(state.get('startDtUtc'), '%Y-%m-%d %H:%M:%S%z').astimezone(timezone.utc)
-                endUtc = datetime.strptime(state.get('endDtUtc'), '%Y-%m-%d %H:%M:%S%z').astimezone(timezone.utc)
+                startUtc = dt_util.parse_datetime(state.get('startDtUtc')).astimezone(timezone.utc)
+                endUtc = dt_util.parse_datetime(state.get('endDtUtc')).astimezone(timezone.utc)
                 all_offpeak_ranges.append({"start": startUtc, "end": endUtc})
 
         # merge overlapping ones:
@@ -201,8 +201,8 @@ class OctopusIntelligentSystem(DataUpdateCoordinator):
         utcnow = dt_util.utcnow() + timedelta(minutes=minutes_offset)
         for state in self.data.get('plannedDispatches', []):
             if source is None or state.get('meta', {}).get('source', '') == source:
-                startUtc = datetime.strptime(state.get('startDtUtc'), '%Y-%m-%d %H:%M:%S%z').astimezone(timezone.utc)
-                endUtc = datetime.strptime(state.get('endDtUtc'), '%Y-%m-%d %H:%M:%S%z').astimezone(timezone.utc)
+                startUtc = dt_util.parse_datetime(state.get('startDtUtc')).astimezone(timezone.utc)
+                endUtc = dt_util.parse_datetime(state.get('endDtUtc')).astimezone(timezone.utc)
                 if startUtc <= utcnow <= endUtc:
                     return True
         return False

--- a/custom_components/octopus_intelligent/select.py
+++ b/custom_components/octopus_intelligent/select.py
@@ -31,8 +31,15 @@ class OctopusIntelligentTargetSoc(CoordinatorEntity, SelectEntity):
     def __init__(self, octopus_system) -> None:
         """Initialize the select."""
         super().__init__(octopus_system)
-        self._unique_id = "octopus_intelligent_target_soc"
-        self._name = "Octopus Target State of Charge"
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Target State of Charge{device_suffix}"
+
+        if octopus_system.device_id:
+            self._unique_id = f"octopus_intelligent_target_soc_{octopus_system.device_id}"
+        else:
+             self._unique_id = "octopus_intelligent_target_soc"
+             
         self._octopus_system = octopus_system
 
         self._current_option = None
@@ -108,8 +115,15 @@ class OctopusIntelligentTargetTime(CoordinatorEntity, SelectEntity):
     def __init__(self, octopus_system) -> None:
         """Initialize the select."""
         super().__init__(octopus_system)
-        self._unique_id = "octopus_intelligent_target_time"
-        self._name = "Octopus Target Ready By Time"
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Target Ready By Time{device_suffix}"
+
+        if octopus_system.device_id:
+            self._unique_id = f"octopus_intelligent_target_time_{octopus_system.device_id}"
+        else:
+             self._unique_id = "octopus_intelligent_target_time"
+             
         self._octopus_system = octopus_system
 
         self._current_option = None

--- a/custom_components/octopus_intelligent/sensor.py
+++ b/custom_components/octopus_intelligent/sensor.py
@@ -39,8 +39,16 @@ class OctopusIntelligentNextOffpeakTime(CoordinatorEntity, SensorEntity):
     def __init__(self, hass, octopus_system) -> None:
         """Initialize the sensor."""
         super().__init__(octopus_system)
-        self._name = "Octopus Intelligent Next Offpeak Start"
-        self._unique_id = slugify(self._name)
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Intelligent Next Offpeak Start{device_suffix}"
+        
+        # Keep unique_id consistent but unique per device
+        if octopus_system.device_id:
+             self._unique_id = slugify(f"octopus_intelligent_next_offpeak_start_{octopus_system.device_id}")
+        else:
+             self._unique_id = slugify("Octopus Intelligent Next Offpeak Start")
+             
         self._octopus_system = octopus_system
         self._timer = async_track_utc_time_change(
             hass, self.timer_update, minute=range(0, 60, 30), second=1)
@@ -117,8 +125,16 @@ class OctopusIntelligentOffpeakEndTime(CoordinatorEntity, SensorEntity):
     def __init__(self, hass, octopus_system) -> None:
         """Initialize the sensor."""
         super().__init__(octopus_system)
-        self._name = "Octopus Intelligent Offpeak End"
-        self._unique_id = slugify(self._name)
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Intelligent Offpeak End{device_suffix}"
+
+        # Keep unique_id consistent but unique per device
+        if octopus_system.device_id:
+             self._unique_id = slugify(f"octopus_intelligent_offpeak_end_{octopus_system.device_id}")
+        else:
+             self._unique_id = slugify("Octopus Intelligent Offpeak End")
+             
         self._octopus_system = octopus_system
         self._timer = async_track_utc_time_change(
             hass, self.timer_update, minute=range(0, 60, 30), second=1)

--- a/custom_components/octopus_intelligent/strings.json
+++ b/custom_components/octopus_intelligent/strings.json
@@ -1,7 +1,9 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Already configured"
+      "already_configured": "Already configured",
+      "no_devices_found": "No Octopus Intelligent devices found on this account.",
+      "cannot_fetch_devices": "Could not fetch devices from Octopus API."
     },
     "error": {
       "cannot_connect": "Failed to connect, please try again.",
@@ -19,6 +21,13 @@
           "offpeak_end": "Offpeak End (normally 05:30)"
         },
         "title": "Octopus Intelligent"
+      },
+      "device": {
+        "title": "Select Device",
+        "description": "Please select the Intelligent device you want to control.",
+        "data": {
+            "device_id": "Device"
+        }
       }
     }
   },

--- a/custom_components/octopus_intelligent/switch.py
+++ b/custom_components/octopus_intelligent/switch.py
@@ -27,8 +27,15 @@ class OctopusIntelligentBumpChargeSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(self, octopus_system) -> None:
         """Initialize the switch."""
         super().__init__(octopus_system)
-        self._unique_id = "octopus_intelligent_bump_charge"
-        self._name = "Octopus Bump Charge"
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Bump Charge{device_suffix}"
+        
+        if octopus_system.device_id:
+            self._unique_id = f"octopus_intelligent_bump_charge_{octopus_system.device_id}"
+        else:
+             self._unique_id = "octopus_intelligent_bump_charge"
+             
         self._octopus_system = octopus_system
         self._is_on = octopus_system.is_boost_charging_now()
 
@@ -95,8 +102,15 @@ class OctopusIntelligentSmartChargeSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(self, octopus_system) -> None:
         """Initialize the switch."""
         super().__init__(octopus_system)
-        self._unique_id = "octopus_intelligent_smart_charging"
-        self._name = "Octopus Smart Charging"
+        
+        device_suffix = f" ({octopus_system.device_id})" if octopus_system.device_id else ""
+        self._name = f"Octopus Smart Charging{device_suffix}"
+        
+        if octopus_system.device_id:
+            self._unique_id = f"octopus_intelligent_smart_charging_{octopus_system.device_id}"
+        else:
+             self._unique_id = "octopus_intelligent_smart_charging"
+             
         self._octopus_system = octopus_system
         self._is_on = octopus_system.is_smart_charging_enabled()
 

--- a/custom_components/octopus_intelligent/translations/en.json
+++ b/custom_components/octopus_intelligent/translations/en.json
@@ -1,7 +1,9 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Already configured"
+      "already_configured": "Already configured",
+      "no_devices_found": "No Octopus Intelligent devices found on this account.",
+      "cannot_fetch_devices": "Could not fetch devices from Octopus API."
     },
     "error": {
       "cannot_connect": "Failed to connect, please try again.",
@@ -19,6 +21,13 @@
           "offpeak_end": "Offpeak End (normally 05:30)"
         },
         "title": "Octopus Intelligent"
+      },
+      "device": {
+        "title": "Select Device",
+        "description": "Please select the Intelligent device you want to control.",
+        "data": {
+            "device_id": "Device"
+        }
       }
     }
   },


### PR DESCRIPTION
Allow users to select a specific Octopus Intelligent device during setup and enable multiple integration installations for different devices.

Previously, the integration arbitrarily selected one device from an account and did not allow users to configure multiple devices. This PR addresses that by introducing a device selection step in the configuration flow and changing the unique identifier to the device ID, enabling separate installations for each device.

---
<a href="https://cursor.com/background-agent?bcId=bc-354e166b-5591-452e-abd0-2b5118551022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-354e166b-5591-452e-abd0-2b5118551022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a device-selection step and propagates device_id across API calls and entities, enabling multiple per-device installations with distinct names/IDs.
> 
> - **Config Flow**:
>   - Add device selection step (`CONF_DEVICE_ID`) with device fetching, auto-select when single, new abort reasons; set entry `unique_id` to `device_id` and use device label as title.
>   - Options flow preserves existing `device_id` while updating other fields.
> - **System/Coordinator** (`octopus_intelligent_system.py`):
>   - Accept and expose `device_id`; pass it to GraphQL calls for fetch and control (suspend/resume, set preferences).
>   - Use `dt_util.parse_datetime` for dispatch times.
> - **GraphQL Client**:
>   - New `async_get_devices` and device-scoped `async_get_combined_state`; support `device_id` in `set_charge_preferences`, suspend/resume mutations; fallback to legacy flows when absent.
>   - Device query + filtering/normalization; helper to resolve `device_id` when not provided.
> - **Entities** (binary_sensor, sensor, select, switch):
>   - Append device suffix to names; make `unique_id`s per-device (include `device_id`).
> - **Constants/Translations**:
>   - Add `CONF_DEVICE_ID`; update strings/translations for device selection and new abort reasons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f49fd80a0754fd221d01c6461cce47bbbc19d7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->